### PR TITLE
Allow empty server_url if enable_registration = false

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Refer to [http://docs.graylog.org/en/latest/pages/collector.html#global-settings
 
 __server_url__
 
-Required. Specifies the URL (including port) for the Graylog2 server.
+Required if enable_registration is true. Specifies the URL (including port) for the Graylog2 server.
 
 __enable_registration__
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,7 @@
 # == Class: graylog_collector
 #
 class graylog_collector (
-  $server_url,
+  $server_url          = undef,
   $enable_registration = true,
   $collector_id        = 'file:/etc/graylog/collector/collector-id',
   $install_path        = '/usr/share',
@@ -28,7 +28,9 @@ class graylog_collector (
 
   validate_re($install_from, '(archive|package)')
 
-  validate_re($server_url, '^https?:\/\/.*:\d+')
+  if ($enable_registration == true) {
+    validate_re($server_url, '^https?:\/\/.*:\d+')
+  }
 
   validate_bool($enable_registration)
   validate_bool($manage_user)

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -8,6 +8,24 @@ describe 'graylog_collector' do
           facts.merge({:concat_basedir => '/tmp'})
         end
 
+        context "no server_url with default parameters" do
+          let(:params) {{ }}
+
+          it { expect { catalogue }.to raise_error(Puppet::Error, /does not match/) }
+        end
+
+        context "enable_registration = false" do
+          let(:params) {{ :enable_registration => false }}
+
+          it { is_expected.to contain_class('graylog_collector') }
+          it { is_expected.to contain_class('graylog_collector::install') }
+          it { is_expected.to contain_class('graylog_collector::config') }
+          it { is_expected.to contain_class('graylog_collector::service') }
+
+          it { is_expected.not_to contain_user('root') }
+          it { is_expected.not_to contain_group('root') }
+        end
+
         context "graylog_collector class without any parameters" do
           let(:params) {{ :server_url => 'https://localhost:12900' }}
 

--- a/templates/config_head.conf.erb
+++ b/templates/config_head.conf.erb
@@ -5,7 +5,9 @@
 // ===========================================================================
 
 // URL to REST API of Graylog server this collector registers at
+<% if @server_url -%>
 server-url = "<%= @server_url %>"
+<% end -%>
 
 // Enable registration with the Graylog server. (enabled by default)
 enable-registration = <%= @enable_registration %>


### PR DESCRIPTION
if you want no registration  on your graylog server, you don't need to set the server_url.

Default is the same, but if you set enable_registration = false, you can leave server_url empty
