### PR TITLE
fetch group var to local namespace

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -7,6 +7,7 @@ class graylog_collector::service (
     $service_file     = $::graylog_collector::service_file,
     $service_template = $::graylog_collector::service_template,
     $user             = $::graylog_collector::user,
+    $group            = $::graylog_collector::group,
     $install_path     = $::graylog_collector::install_path,
     $config_dir       = $::graylog_collector::config_dir,
     $sysconfig_dir    = $::graylog_collector::sysconfig_dir,


### PR DESCRIPTION
$group is missing for future parser. works on the old parser and with the future parser
