### PR TITLE
:config::config_dir is not available

### DIFF
--- a/manifests/input.pp
+++ b/manifests/input.pp
@@ -13,7 +13,7 @@ define graylog_collector::input (
   $charset                  = 'UTF-8',
   $reader_interval          = '100ms',
   $priority                 = '101',
-  $config_dir               = $graylog_collector::config::config_dir,
+  $config_dir               = $graylog_collector::config_dir,
   $global_message_fields    = {},
   $message_fields           = {},
   $outputs                  = undef,

--- a/manifests/output.pp
+++ b/manifests/output.pp
@@ -17,7 +17,7 @@ define graylog_collector::output (
   $client_send_buffer_size    = '-1',
   $inputs                     = undef,
   $priority                   = '401',
-  $config_dir                 = $graylog_collector::config::config_dir,
+  $config_dir                 = $graylog_collector::config_dir,
 ) {
 
   validate_re($type, '(stdout|gelf)')


### PR DESCRIPTION
in Puppet 4.x graylog_collector::config::config_dir is not available,
because it is later used at init.pp.

Error: Could not retrieve catalog from remote server: Error 500 on
SERVER: {"message":"Server Error: Invalid relationship:
File[/var/lib/puppet/concat/_collector.conf/fragments/101_input_webapp_login_log]
{ notify => Exec[concat_/collector.conf] }, because
Exec[concat_/collector.conf] doesn't seem to be in the catalog"

This change is tested with Puppet Server (Puppet 4.6) and Puppet 3.8.x
with future parser enabled
